### PR TITLE
Define PY_SSIZE_T_CLEAN for Python 3.10 compatibility

### DIFF
--- a/skip32/skip32.c
+++ b/skip32/skip32.c
@@ -16,6 +16,7 @@
     Keith Bussell: Added python wrapping code 7/11/2008
  */
 
+#define PY_SSIZE_T_CLEAN /* Make "z#" use Py_ssize_t rather than int. */
 #include <Python.h>
 
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
From https://docs.python.org/3/c-api/arg.html#arg-parsing

> For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python 3.9 and older, the type of the length argument is Py_ssize_t if the PY_SSIZE_T_CLEAN macro is defined, or int otherwise.

As `fk-skip32` uses `z#` we need to define `PY_SSIZE_T_CLEAN`.